### PR TITLE
Publicly re-export euclid::{TypedRect, TypedPoint2D, TypedSize2D}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use fnv::FnvHasher;
 use std::cmp::Ord;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use euclid::{TypedRect, TypedPoint2D, TypedSize2D};
+pub use euclid::{TypedRect, TypedPoint2D, TypedSize2D};
 
 type FnvHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
 


### PR DESCRIPTION
Thanks for putting out aabb-quadtree under an open source license! It seems useful!

Here's a pull-request to make it slightly easier to use.

Publicly re-export euclid::{TypedRect, TypedPoint2D, TypedSize2D}, so that users don't need to figure out which version of euclid to include to be able to use aabb_quadtree.

As it is now, the consumer of the API needs to be able to instantiate TypedRect, and to do this they need to depend on euclid (if I'm not mistaken, please correct me if I'm wrong!). However, the correct version of euclid needs to be chosen, otherwise cargo will download and build a parallel version of euclid which will contain distinct types, making it impossible to instantiate TypedRect usablel with aabb_quadtree.

By re-exporting the correct version of TypedRect, TypedPoint2D and TypedSize2D, the user can use the library without explicitly depending on euclid.
