### PR TITLE
Add repository so folks can find the source code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aabb-quadtree"
 version = "0.1.0"
 authors = ["Ty Overby <ty@pre-alpha.com>"]
+repository = "https://github.com/TyOverby/aabb-quadtree"
 
 description="A quadtree that maps bounding-boxes to elements"
 license="MIT/Apache-2.0"


### PR DESCRIPTION
Docs.rs doesn't know how to reference the Github page without the "repository" key. I built my own as I thought this one might have been closed source. It was a good excuse for some practice at least. :D